### PR TITLE
Feature: Launch Cursor with user defined flags

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -9,35 +9,33 @@ url="https://www.cursor.com/"
 license=('custom:Proprietary')  # Replace with the correct license if known
 depends=('fuse2')
 options=(!strip)
-source_x86_64=("https://download.todesktop.com/230313mzl4w4u92/cursor-0.44.2-build-241218ntls52u8v-x86_64.AppImage" "cursor.png")
-noextract=("$(basename ${source_x86_64[0]})")
+_appimage="${pkgname}-${pkgver}.AppImage"
+source_x86_64=("${_appimage}::https://download.todesktop.com/230313mzl4w4u92/cursor-0.44.2-build-241218ntls52u8v-x86_64.AppImage" "cursor.png" "${pkgname}.desktop.in" "${pkgname}.sh")
+noextract=("${_appimage}")
 sha512sums_x86_64=('516b188a4766219defefe58b574ec66dd272d172daecb3ee47cb7981219f5f26e6a0ba182229f8f9b72fd3e1194b037e5d1563f6324b429f152b8110a5e1d10d'
-                   'f948c5718c2df7fe2cae0cbcd95fd3010ecabe77c699209d4af5438215daecd74b08e03d18d07a26112bcc5a80958105fda724768394c838d08465fce5f473e7')
+                   'f948c5718c2df7fe2cae0cbcd95fd3010ecabe77c699209d4af5438215daecd74b08e03d18d07a26112bcc5a80958105fda724768394c838d08465fce5f473e7'
+                   'e7e355524db7ddca2e02351f5af6ade791646b42434400f03f84e1068a43aadaa469ba6d5acbc16e6a3a7e52be4807b498585bea3f566e19b66414f6c3095154'
+                   'ec3fa93a7df3ac97720d57e684f8745e3e34f39d9976163ea0001147961ca4caeb369de9d1e80c877bb417a0f1afa49547d154dde153be7fe6615092894cff47')
+
+prepare() {
+    # Set correct version in .desktop file
+    sed "s/@@PKGVERSION@@/${pkgver}/g" "${srcdir}/${pkgname}.desktop.in" > "${srcdir}/cursor-cursor.desktop"
+}
+
 package() {
-    install -Dm755 "${srcdir}/$(basename ${source_x86_64[0]})" "${pkgdir}/opt/${pkgname}/${pkgname}.AppImage"
+    # Create directories
+    install -d "${pkgdir}/opt/${pkgname}"
+    install -d "${pkgdir}/usr/bin"
+    install -d "${pkgdir}/usr/share/applications"
+    install -d "${pkgdir}/usr/share/icons"
 
-    # Symlink executable to be called 'cursor'
-    mkdir -p "${pkgdir}/usr/bin"
-    ln -s "/opt/${pkgname}/${pkgname}.AppImage" "${pkgdir}/usr/bin/cursor"
+    # Install files with proper permissions
+    install -m644 "${srcdir}/cursor-cursor.desktop" "${pkgdir}/usr/share/applications/cursor-cursor.desktop"
+    install -m644 "${srcdir}/cursor.png" "${pkgdir}/usr/share/icons/cursor.png"
+    install -m755 "${srcdir}/${_appimage}" "${pkgdir}/opt/${pkgname}/${pkgname}.AppImage"
 
-    # Install the icon
-    install -Dm644 "${srcdir}/cursor.png" "${pkgdir}/usr/share/icons/hicolor/512x512/apps/cursor.png"
-
-    # Create a .desktop Entry
-    mkdir -p "${pkgdir}/usr/share/applications"
-    cat <<EOF > "${pkgdir}/usr/share/applications/cursor-cursor.desktop"
-[Desktop Entry]
-Name=Cursor
-Exec=/usr/bin/cursor --no-sandbox %U
-Terminal=false
-Type=Application
-Icon=cursor
-# Change the class below to "Cursor" when on X11
-StartupWMClass=cursor-url-handler
-X-AppImage-Version=${pkgver}
-MimeType=x-scheme-handler/cursor;
-Categories=Utility;TextEditor;Development;IDE
-EOF
+    # Install executable to be called 'cursor', that can load user flags from $XDG_CONFIG_HOME/cursor-flags.conf
+    install -m755 "${srcdir}/${pkgname}.sh" "${pkgdir}/usr/bin/cursor"
 }
 
 post_install() {

--- a/check.py
+++ b/check.py
@@ -48,7 +48,7 @@ def get_local_pkgbuild_info():
         content = file.read()
     version_match = re.search(r'pkgver=([^\n]+)', content)
     rel_match = re.search(r'pkgrel=(\d+)', content)
-    source_match = re.search(r'source_x86_64=\("([^"]+)"', content)
+    source_match = re.search(r'source_x86_64=\(".*?::([^"]+)"', content)
     if version_match and rel_match and source_match:
         return version_match.group(1).strip(), rel_match.group(1), source_match.group(1)
     else:

--- a/cursor-bin.desktop.in
+++ b/cursor-bin.desktop.in
@@ -1,0 +1,11 @@
+[Desktop Entry]
+Name=Cursor
+Exec=/usr/bin/cursor --no-sandbox %U
+Terminal=false
+Type=Application
+Icon=cursor
+# Change the class below to "Cursor" when on X11
+StartupWMClass=cursor-url-handler
+X-AppImage-Version=@@PKGVERSION@@
+MimeType=x-scheme-handler/cursor;
+Categories=Utility;TextEditor;Development;IDE

--- a/cursor-bin.sh
+++ b/cursor-bin.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+XDG_CONFIG_HOME=${XDG_CONFIG_HOME:-~/.config}
+
+# Allow users to override command-line options
+if [[ -f $XDG_CONFIG_HOME/cursor-flags.conf ]]; then
+  CURSOR_USER_FLAGS="$(sed 's/#.*//' $XDG_CONFIG_HOME/cursor-flags.conf | tr '\n' ' ')"
+fi
+
+# Launch
+exec /opt/cursor-bin/cursor-bin.AppImage "$@" $CURSOR_USER_FLAGS

--- a/update_pkgbuild.py
+++ b/update_pkgbuild.py
@@ -18,6 +18,8 @@ def update_pkgbuild(pkgbuild_lines, json_data):
     new_rel = json_data['new_rel']
     download_sha512 = base64_to_hex(json_data['download_sha512'])
     cursor_png_checksum = 'f948c5718c2df7fe2cae0cbcd95fd3010ecabe77c699209d4af5438215daecd74b08e03d18d07a26112bcc5a80958105fda724768394c838d08465fce5f473e7'
+    cursor_desktop_checksum = 'e7e355524db7ddca2e02351f5af6ade791646b42434400f03f84e1068a43aadaa469ba6d5acbc16e6a3a7e52be4807b498585bea3f566e19b66414f6c3095154'
+    cursor_launcher_checksum = 'ec3fa93a7df3ac97720d57e684f8745e3e34f39d9976163ea0001147961ca4caeb369de9d1e80c877bb417a0f1afa49547d154dde153be7fe6615092894cff47'
 
     updated_lines = []
     in_sha = False
@@ -28,14 +30,14 @@ def update_pkgbuild(pkgbuild_lines, json_data):
         elif line.startswith('pkgrel='):
             updated_lines.append(f'pkgrel={new_rel}\n')
         elif line.startswith('source_x86_64='):
-            updated_lines.append(f'source_x86_64=("{download_link}" "cursor.png")\n')
-        elif line.startswith('noextract='):
-            updated_lines.append('noextract=("$(basename ${source_x86_64[0]})")\n')
+            updated_lines.append(f'source_x86_64=("${{_appimage}}::{download_link}" "cursor.png" "${{pkgname}}.desktop.in" "${{pkgname}}.sh")\n')
         elif line.startswith('sha512sums_x86_64='):
             updated_lines.append(f"sha512sums_x86_64=('{download_sha512}'\n")
             in_sha = True
         elif in_sha and line.strip().endswith(')'):
-            updated_lines.append(f"                   '{cursor_png_checksum}')\n")
+            updated_lines.append(f"                   '{cursor_png_checksum}'\n")
+            updated_lines.append(f"                   '{cursor_desktop_checksum}'\n")
+            updated_lines.append(f"                   '{cursor_launcher_checksum}')\n")
             in_sha = False
         elif not in_sha:
             updated_lines.append(line)


### PR DESCRIPTION
Similar to `visual-studio-code-bin` or `code` this allows the user to provide flags that Cursor should start with in a config file (`${XDG_CONFIG_HOME:-~/.config}/cursor-flags.conf`).

I've also done some cleanups, mainly extracting the inline `.desktop` file.