### PR TITLE
Use update-desktop-database.hook

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -37,7 +37,3 @@ package() {
     # Install executable to be called 'cursor', that can load user flags from $XDG_CONFIG_HOME/cursor-flags.conf
     install -m755 "${srcdir}/${pkgname}.sh" "${pkgdir}/usr/bin/cursor"
 }
-
-post_install() {
-    xdg-icon-resource forceupdate
-}

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -39,6 +39,5 @@ package() {
 }
 
 post_install() {
-    update-desktop-database -q
     xdg-icon-resource forceupdate
 }


### PR DESCRIPTION
It has `/usr/bin/update-desktop-database --quiet`. So it is removed from `post_install()`