### PR TITLE
Extract AppImage

### DIFF
--- a/cursor-bin.sh
+++ b/cursor-bin.sh
@@ -7,5 +7,6 @@ if [[ -f $XDG_CONFIG_HOME/cursor-flags.conf ]]; then
   CURSOR_USER_FLAGS="$(sed 's/#.*//' $XDG_CONFIG_HOME/cursor-flags.conf | tr '\n' ' ')"
 fi
 
-# Launch
-exec /opt/cursor-bin/cursor-bin.AppImage "$@" $CURSOR_USER_FLAGS
+# Run with flags
+_app=/usr/share/cursor/resources/app
+ELECTRON_RUN_AS_NODE=1 exec /usr/share/cursor/electron ${_app}/out/cli.js "$CURSOR_USER_FLAGS" --app=${_app} "$@"


### PR DESCRIPTION
1. Extracts appImage and adjust laincher for it. Local `.png` and `.desktop.in` is no linger used.
2. Supress some warnings by `namcap`.
3.  Replace `rg` with system's optimized one.

Closes https://github.com/Gunther-Schulz/aur-cursor-bin-updater/issues/12

Size:  `372.07 MiB` (including bundled Electron)