### PR TITLE
fix: disable AppImageLauncher integration for Cursor process only

### DIFF
--- a/cursor-bin.sh
+++ b/cursor-bin.sh
@@ -7,5 +7,5 @@ if [[ -f $XDG_CONFIG_HOME/cursor-flags.conf ]]; then
   CURSOR_USER_FLAGS="$(sed 's/#.*//' $XDG_CONFIG_HOME/cursor-flags.conf | tr '\n' ' ')"
 fi
 
-# Launch
-exec /opt/cursor-bin/cursor-bin.AppImage "$@" $CURSOR_USER_FLAGS
+# Launch with AppImageLauncher disabled only for this process
+APPIMAGELAUNCHER_DISABLE=TRUE exec /opt/cursor-bin/cursor-bin.AppImage "$@" $CURSOR_USER_FLAGS


### PR DESCRIPTION
If [appimagelauncher](https://github.com/TheAssassin/AppImageLauncher) utility is present on the system it would pop up and ask for integration on every launch, if "integrate" is selected it would try to move it to its own defined location and rename it, create its own desktop files and so on because this is an AUR package of itself and not a manually download appimage, I don't think that's desirable.

this pull request adds a `APPIMAGELAUNCHER_DISABLE=TRUE` environment variable to the cursor launch script 