### PR TITLE
Drop vendored Electron

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -3,42 +3,52 @@
 pkgname=cursor-bin
 pkgver=1.1.4
 pkgrel=1
-pkgdesc="Cursor App - AI-first coding environment"
+pkgdesc='AI-first coding environment'
 arch=('x86_64')
-url="https://www.cursor.com/"
-license=('custom:Proprietary')  # Replace with the correct license if known
-depends=('fuse2' 'gtk3')
-options=(!strip)
+url="https://www.cursor.com"
+license=('LicenseRef-Cursor_EULA')
+# electron* is added at package()
+depends=('ripgrep' 'xdg-utils'
+  'gcc-libs' 'hicolor-icon-theme' 'libxkbfile')
+options=(!strip) # Don't break ext of VSCode
 _appimage="${pkgname}-${pkgver}.AppImage"
-source_x86_64=("${_appimage}::https://downloads.cursor.com/production/e86fcc937643bc6385aebd982c1c66012c98caec/linux/x64/Cursor-1.1.4-x86_64.AppImage" "cursor.png" "${pkgname}.desktop.in" "${pkgname}.sh")
-noextract=("${_appimage}")
-sha512sums_x86_64=('86ca588558b08e30187d32963a07b68a79ad0e762845f20066b044cd82ebee4839466c92b7464cf59593054e2221eca4580566c08914a6ad102fd4e4e62a6ddc'
-                   'f948c5718c2df7fe2cae0cbcd95fd3010ecabe77c699209d4af5438215daecd74b08e03d18d07a26112bcc5a80958105fda724768394c838d08465fce5f473e7'
-                   '813d42d46f2e6aad72a599c93aeb0b11a668ad37b3ba94ab88deec927b79c34edf8d927e7bb2140f9147b086562736c3f708242183130824dd74b7a84ece67aa'
-                   'ec3fa93a7df3ac97720d57e684f8745e3e34f39d9976163ea0001147961ca4caeb369de9d1e80c877bb417a0f1afa49547d154dde153be7fe6615092894cff47')
+_commit=e86fcc937643bc6385aebd982c1c66012c98caec
+source=("${_appimage}::https://downloads.cursor.com/production/${_commit}/linux/x64/Cursor-${pkgver}-x86_64.AppImage"
+https://gitlab.archlinux.org/archlinux/packaging/packages/code/-/raw/main/code.sh)
+sha512sums=('86ca588558b08e30187d32963a07b68a79ad0e762845f20066b044cd82ebee4839466c92b7464cf59593054e2221eca4580566c08914a6ad102fd4e4e62a6ddc'
+            '937299c6cb6be2f8d25f7dbc95cf77423875c5f8353b8bd6cd7cc8e5603cbf8405b14dbf8bd615db2e3b36ed680fc8e1909410815f7f8587b7267a699e00ab37')
 
+_app=/usr/share/cursor/resources/app
 prepare() {
-    # Set correct version in .desktop file
-    sed "s/@@PKGVERSION@@/${pkgver}/g" "${srcdir}/${pkgname}.desktop.in" > "${srcdir}/cursor-cursor.desktop"
+  rm -rf squashfs-root # for unclean build
+  chmod +x ${_appimage}
+  ./${_appimage} --appimage-extract > /dev/null
+  cd squashfs-root
+  # Shell completions
+  mv usr/share/zsh/{vendor-completions,site-functions}
+  # Replace Electron
+  mv .${_app} usr/lib/cursor
+  rm -r usr/share/cursor
+  install -d usr/share/cursor/resources
+  mv usr/lib/cursor .${_app}
+  # Replace rg and xdg-open
+  ln -sf /usr/bin/rg       .${_app}/node_modules/@vscode/ripgrep/bin/rg
+  ln -sf /usr/bin/xdg-open .${_app}/node_modules/open/xdg-open
+  # License
+  install -d usr/share/licenses/${pkgname}
+  mv ./${_app}/LICENSE.txt usr/share/licenses/${pkgname}/LICENSE
+  mv ./${_app}/ThirdPartyNotices.txt usr/share/licenses/${pkgname}/
+  # Unused icon name by desktop entries... 1024^2 is slow...
+  rm -r usr/share/icons
+  install -Dm644 co.anysphere.cursor.png usr/share/pixmaps/co.anysphere.cursor.png
 }
 
-package() {
-    # Create directories
-    install -d "${pkgdir}/opt/${pkgname}"
-    install -d "${pkgdir}/usr/bin"
-    install -d "${pkgdir}/usr/share/applications"
-    install -d "${pkgdir}/usr/share/icons"
-
-    # Install files with proper permissions
-    install -m644 "${srcdir}/cursor-cursor.desktop" "${pkgdir}/usr/share/applications/cursor-cursor.desktop"
-    install -m644 "${srcdir}/cursor.png" "${pkgdir}/usr/share/icons/cursor.png"
-    install -m755 "${srcdir}/${_appimage}" "${pkgdir}/opt/${pkgname}/${pkgname}.AppImage"
-
-    # Install executable to be called 'cursor', that can load user flags from $XDG_CONFIG_HOME/cursor-flags.conf
-    install -m755 "${srcdir}/${pkgname}.sh" "${pkgdir}/usr/bin/cursor"
-}
-
-post_install() {
-    update-desktop-database -q
-    xdg-icon-resource forceupdate
+package(){
+  # Allop packaging with other electron by editing PKGBUILD
+  _electron=electron$(rg --no-messages -N -o -r '$1' '"electron": *"[^\d]*(\d+)' squashfs-root${_app}/package.json)
+  echo $_electron
+  depends+=($_electron)
+  cp -r --reflink=auto squashfs-root/usr "${pkgdir}/usr"
+  sed -e "s|code-flags|cursor-flags|" -e "s|/usr/lib/code|${_app}|" -e "s|/usr/lib/code/code.mjs|--app=${_app}|" \
+    -e "s|name=electron|name=${_electron}|" code.sh | install -Dm755 /dev/stdin "${pkgdir}"/usr/share/cursor/cursor
 }


### PR DESCRIPTION
AppImage with vendored Electron is really probrematic:

1. `chrome-sandbox` SUID binary does not work. `--no-sandbox` shoud not be default.
2.  Cursor's AppImage is overriding `$ARGV0`. It is breaking `rustup` at least for. Upstream seems negative to fix it. this is guiding people to submit many duplicated pkgs to AUR with a risk of BAN.
3. Difficult to catch upstream's fix of icon, desktop entries, and licenses.
4. Blocks `namcap` to scan missing deps.
5. `fuse2` has `SUID` binary.

Closes https://github.com/Gunther-Schulz/aur-cursor-bin-updater/issues/12