### PR TITLE
Make launcher script disown process

### DIFF
--- a/cursor-bin.sh
+++ b/cursor-bin.sh
@@ -8,4 +8,5 @@ if [[ -f $XDG_CONFIG_HOME/cursor-flags.conf ]]; then
 fi
 
 # Launch
-exec /opt/cursor-bin/cursor-bin.AppImage "$@" $CURSOR_USER_FLAGS
+exec /opt/cursor-bin/cursor-bin.AppImage --no-sandbox "$@" $CURSOR_USER_FLAGS &> /dev/null &
+disown


### PR DESCRIPTION
I applied suggestions from this thread here: https://forum.cursor.com/t/installing-command-line-launcher-on-linux/7151/9
to the launcher script so that when you launch cursor from the terminal (e.g. with `cursor .`) it doesn't stay attached to the terminal.