### PR TITLE
Switch to deb

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,8 +1,8 @@
 # Maintainer: Gunther Schulz <dev@guntherschulz.de>
 
 pkgname=cursor-bin
-pkgver=1.5.9
-pkgrel=3
+pkgver=1.5.5
+pkgrel=1
 pkgdesc='AI-first coding environment'
 arch=('x86_64')
 url="https://www.cursor.com"
@@ -12,32 +12,27 @@ depends=('ripgrep' 'xdg-utils'
   'gcc-libs' 'hicolor-icon-theme' 'libxkbfile')
 options=(!strip) # Don't break ext of VSCode
 _appimage="${pkgname}-${pkgver}.AppImage"
-_commit=de327274300c6f38ec9f4240d11e82c3b0660b29
-source=("${_appimage}::https://downloads.cursor.com/production/de327274300c6f38ec9f4240d11e82c3b0660b29/linux/x64/Cursor-1.5.9-x86_64.AppImage"
+_commit=823f58d4f60b795a6aefb9955933f3a2f0331d7b # sed'ded at GitHub WF
+source=("https://downloads.cursor.com/production/${_commit}/linux/x64/deb/amd64/deb/cursor_${pkgver}_amd64.deb"
 https://gitlab.archlinux.org/archlinux/packaging/packages/code/-/raw/main/code.sh)
-sha512sums=('c4abae532e55a6efd39d082d805de791f6be2ffe2b764572f20a7156a6699092bf0a0c0d9b3c13975f22c94ee2e872ec4be5a8e750affa7e1a8711604923851c'
+sha512sums=('72f5788ab3ac110df352e27bae7fad1f55ad89974680d93f8705d87374ea5327ad861d4f52f79759db45025d9400c4d70bd048680a1226a25634f38fe272ebc5'
             '937299c6cb6be2f8d25f7dbc95cf77423875c5f8353b8bd6cd7cc8e5603cbf8405b14dbf8bd615db2e3b36ed680fc8e1909410815f7f8587b7267a699e00ab37')
 
 _app=usr/share/cursor/resources/app
 package() {
-  rm -rf squashfs-root
-  chmod +x ${_appimage}
-  # Don't use upstream's broken resources
-  for _f in co.anysphere.cursor.png usr/bin usr/share/{appdata,applications,bash-completion,mime,zsh}
-    do ./${_appimage} --appimage-extract $_f > /dev/null
-  done
-  ./${_appimage} --appimage-extract usr/share/cursor/resources/app > /dev/null
-  cd squashfs-root
+  # Exclude electron
+  bsdtar -xf data.tar.xz --exclude 	'usr/share/cursor/[^r]*' --exclude 'usr/share/windsurf/*.pak'
   mv usr/share/zsh/{vendor-completions,site-functions}
-  install -Dm644 co.anysphere.cursor.png -t usr/share/pixmaps
   ln -svf /usr/bin/rg ${_app}/node_modules/@vscode/ripgrep/bin/rg
   ln -svf /usr/bin/xdg-open ${_app}/node_modules/open/xdg-open
 
-  # Electron version determined during build process
-  _electron=electron34
+  # sed-ded at GitHub WF to electronNM
+  _electron=electron
   echo $_electron
   depends+=($_electron)
   mv usr "${pkgdir}"/usr
   sed -e "s|code-flags|cursor-flags|" -e "s|/usr/lib/code|/${_app}|" -e "s|/usr/lib/code/code.mjs|--app=/${_app}|" \
     -e "s|name=electron|name=${_electron}|" "${srcdir}"/code.sh | install -Dm755 /dev/stdin "${pkgdir}"/usr/share/cursor/cursor
+  install -d "$pkgdir"/usr/bin
+  ln -sf /usr/share/cursor/cursor "$pkgdir"/usr/bin/cursor
 }


### PR DESCRIPTION
Upstream provides `.deb` "only for stable channel" now.
This drops many workarounds for buggy AppImage.

Needs update of GitHub action.