### PR TITLE
fix: remove `ripgrep` replacement, because of cursor's custom rg patches

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -8,21 +8,20 @@ arch=('x86_64')
 url="https://www.cursor.com"
 license=('LicenseRef-Cursor_EULA')
 # electron* is added at package()
-depends=('ripgrep' 'xdg-utils'
+depends=('xdg-utils'
   'gcc-libs' 'hicolor-icon-theme' 'libxkbfile')
-options=(!strip) # Don't break ext of VSCode
+options=(!strip)                                 # Don't break ext of VSCode
 _commit=2f2737de9aa376933d975ae30290447c910fdf46 # sed'ded at GitHub WF
 source=("https://downloads.cursor.com/production/2f2737de9aa376933d975ae30290447c910fdf46/linux/x64/deb/amd64/deb/cursor_1.5.11_amd64.deb"
-https://gitlab.archlinux.org/archlinux/packaging/packages/code/-/raw/main/code.sh)
+  https://gitlab.archlinux.org/archlinux/packaging/packages/code/-/raw/main/code.sh)
 sha512sums=('7c00f358bc37bbc49150f9e12507c6903c3a550358af2690597d07f41b60c643067484f7458c23048ad9e317461cf3bd3df0d400a1c66431466c8f64ba0079f0'
-            '937299c6cb6be2f8d25f7dbc95cf77423875c5f8353b8bd6cd7cc8e5603cbf8405b14dbf8bd615db2e3b36ed680fc8e1909410815f7f8587b7267a699e00ab37')
+  '937299c6cb6be2f8d25f7dbc95cf77423875c5f8353b8bd6cd7cc8e5603cbf8405b14dbf8bd615db2e3b36ed680fc8e1909410815f7f8587b7267a699e00ab37')
 
 _app=usr/share/cursor/resources/app
 package() {
   # Exclude electron
-  bsdtar -xf data.tar.xz --exclude 	'usr/share/cursor/[^r]*' --exclude 'usr/share/windsurf/*.pak'
+  bsdtar -xf data.tar.xz --exclude 'usr/share/cursor/[^r]*' --exclude 'usr/share/windsurf/*.pak'
   mv usr/share/zsh/{vendor-completions,site-functions}
-  ln -svf /usr/bin/rg ${_app}/node_modules/@vscode/ripgrep/bin/rg
   ln -svf /usr/bin/xdg-open ${_app}/node_modules/open/xdg-open
 
   # Electron version determined during build process


### PR DESCRIPTION
cursor has added custom ripgrep options that its agent uses now, specifically one I've seen is `--cursor-ignore`. Each "grep tool" usage will break without this option being supported by the rg binary.

I've tested this patch, and everything works with just removing the `depends` and replacement works. Not sure about arm(?)

Example:
<img width="886" height="160" alt="image" src="https://github.com/user-attachments/assets/b62b3915-6866-4872-aa57-41618484d9bd" />
