### PR TITLE
AUR publish stuck at 3.0.13 — deploy-aur action fails with `bash: --command: invalid option`

### DIFF
--- a/.github/workflows/update-aur.yml
+++ b/.github/workflows/update-aur.yml
@@ -148,7 +148,7 @@ jobs:
 
       - name: Publish AUR package
         if: steps.check.outputs.update_needed == 'true' && github.ref != 'refs/heads/development'
-        uses: KSXGitHub/github-actions-deploy-aur@v2.7.2
+        uses: KSXGitHub/github-actions-deploy-aur@v4.1.2
         with:
           pkgname: cursor-bin
           pkgbuild: ./PKGBUILD


### PR DESCRIPTION
## Summary

The AUR package is stuck at version 3.0.13 while the upstream Cursor stable API already reports 3.0.16. The GitHub repo PKGBUILD was correctly updated to 3.0.16 in commit 4aa861c (April 9), but the AUR never received the update because the "Publish AUR package" step failed on that run and all subsequent runs skip publishing since the PKGBUILD already matches the API version.

## Failed run

https://github.com/Gunther-Schulz/aur-cursor-bin-updater/actions/runs/24209320159

## Root cause

The `KSXGitHub/github-actions-deploy-aur@v2.7.2` action fails inside its Arch Linux Docker container with:

```
bash: --command: invalid option
```

This happens after SSH setup completes but before the AUR repo is cloned or pushed to. It appears the `archlinux:base` Docker image now ships a version of bash that doesn't accept `--command` as a long option (expects `-c` instead).

This was fixed upstream in [KSXGitHub/github-actions-deploy-aur#49](https://github.com/KSXGitHub/github-actions-deploy-aur/pull/49), released as `v4.1.2`.

## Changes

- Upgrades `KSXGitHub/github-actions-deploy-aur` from `v2.7.2` to `v4.1.2`

## Impact

Because the workflow compares the local PKGBUILD version against the Cursor update API, and both now say 3.0.16, every subsequent hourly run reports "No update needed" and skips the publish step entirely. The AUR will remain stuck at 3.0.13 until this is merged.

**Note:** After merging, a `pkgrel` bump or manual re-trigger will be needed to unstick the AUR, since the version comparison currently sees no change.