### PR TITLE
fix(ci): check AUR API version to prevent deployment desync

### DIFF
--- a/.github/workflows/update-aur.yml
+++ b/.github/workflows/update-aur.yml
@@ -20,7 +20,15 @@ jobs:
           # Get current version from PKGBUILD
           current_pkgver=$(grep -E '^pkgver=' PKGBUILD | cut -d'=' -f2)
           current_commit=$(grep -E '^_commit=' PKGBUILD | cut -d'=' -f2 | sed 's/ #.*//')
-          echo "Current version: $current_pkgver (commit: ${current_commit:0:8})"
+          echo "Local version: $current_pkgver (commit: ${current_commit:0:8})"
+
+          # Get current version from AUR
+          aur_response=$(curl -sf "https://aur.archlinux.org/rpc/?v=5&type=info&arg[]=cursor-bin")
+          aur_pkgver=""
+          if [ -n "$aur_response" ]; then
+            aur_pkgver=$(echo "$aur_response" | jq -r '.results[0].Version // empty' | cut -d'-' -f1)
+          fi
+          echo "AUR version: ${aur_pkgver:-unknown}"
 
           # Query the stable update API
           api_response=$(curl -sf "https://api2.cursor.sh/updates/api/update/linux-x64/cursor/0.0.0/deadbeef/stable")
@@ -41,8 +49,8 @@ jobs:
           echo "Latest: $new_pkgver (commit: ${new_commit:0:8})"
 
           # Check if update is needed
-          if [ "$current_pkgver" = "$new_pkgver" ] && [ "$current_commit" = "$new_commit" ]; then
-            echo "No update needed. Current version matches latest."
+          if [ "$current_pkgver" = "$new_pkgver" ] && [ "$current_commit" = "$new_commit" ] && [ "${aur_pkgver:-$current_pkgver}" = "$new_pkgver" ]; then
+            echo "No update needed. Local and AUR versions match latest."
             echo "update_needed=false" >> $GITHUB_OUTPUT
             exit 0
           fi


### PR DESCRIPTION
Previously, the workflow only checked the local PKGBUILD version to determine if an update was needed. If a deployment to AUR failed but the local commit succeeded, subsequent runs would incorrectly skip the update since the local version matched the upstream release.
This fix queries the Arch Linux AUR RPC API and requires both the local PKGBUILD and the published AUR package to match the upstream version before skipping the update.
<img width="1909" height="960" alt="Screenshot From 2026-04-10 15-30-28" src="https://github.com/user-attachments/assets/7aa1c19a-1d94-4de0-947c-2832227b4917" />
<img width="1909" height="960" alt="Screenshot From 2026-04-10 15-29-24" src="https://github.com/user-attachments/assets/63ff7a11-bf9c-49b8-b597-77cca1d8d0a4" />
