### PR TITLE
Fix electron dependency detection and pkgrel bump logic

### DIFF
--- a/.github/workflows/update-aur.yml
+++ b/.github/workflows/update-aur.yml
@@ -17,18 +17,42 @@ jobs:
         run: |
           echo "::group::Checking for updates"
 
+          detect_electron_from_deb() {
+            local deb=$1 tmpdir major
+            tmpdir=$(mktemp -d)
+            cp "$deb" "$tmpdir/pkg.deb"
+            (cd "$tmpdir" && ar x pkg.deb data.tar.xz)
+            major=$(tar xJf "$tmpdir/data.tar.xz" -O ./usr/share/cursor/cursor \
+              | strings | grep -oE 'Electron/[0-9]+' | head -1 | cut -d/ -f2)
+            rm -rf "$tmpdir"
+            if [ -z "$major" ]; then
+              echo "ERROR: Failed to detect Electron version from .deb" >&2
+              exit 1
+            fi
+            echo "electron${major}"
+          }
+
           # Get current version from PKGBUILD
           current_pkgver=$(grep -E '^pkgver=' PKGBUILD | cut -d'=' -f2)
+          current_pkgrel=$(grep -E '^pkgrel=' PKGBUILD | cut -d'=' -f2)
+          current_pkgrel=${current_pkgrel:-1}
           current_commit=$(grep -E '^_commit=' PKGBUILD | cut -d'=' -f2 | sed 's/ #.*//')
-          echo "Local version: $current_pkgver (commit: ${current_commit:0:8})"
+          current_electron=$(grep -E '^_electron=' PKGBUILD | cut -d'=' -f2)
+          current_sha=$(grep -E '^sha512sums\[0\]=' PKGBUILD | cut -d'=' -f2)
+          echo "Local version: ${current_pkgver}-${current_pkgrel} (commit: ${current_commit:0:8}, ${current_electron})"
 
           # Get current version from AUR
           aur_response=$(curl -sf "https://aur.archlinux.org/rpc/?v=5&type=info&arg[]=cursor-bin")
           aur_pkgver=""
+          aur_pkgrel=""
+          aur_electron=""
           if [ -n "$aur_response" ]; then
-            aur_pkgver=$(echo "$aur_response" | jq -r '.results[0].Version // empty' | cut -d'-' -f1)
+            aur_version=$(echo "$aur_response" | jq -r '.results[0].Version // empty')
+            aur_pkgver=$(echo "$aur_version" | cut -d'-' -f1)
+            aur_pkgrel=$(echo "$aur_version" | cut -d'-' -f2)
+            aur_electron=$(echo "$aur_response" | jq -r '.results[0].Depends[]? | select(test("^electron"))' | head -1)
           fi
-          echo "AUR version: ${aur_pkgver:-unknown}"
+          echo "AUR version: ${aur_pkgver:-unknown}-${aur_pkgrel:-?} (${aur_electron:-unknown electron dep})"
 
           # Query the stable update API
           api_response=$(curl -sf "https://api2.cursor.sh/updates/api/update/linux-x64/cursor/0.0.0/deadbeef/stable")
@@ -48,53 +72,89 @@ jobs:
 
           echo "Latest: $new_pkgver (commit: ${new_commit:0:8})"
 
-          # Check if update is needed
-          if [ "$current_pkgver" = "$new_pkgver" ] && [ "$current_commit" = "$new_commit" ] && [ "${aur_pkgver:-$current_pkgver}" = "$new_pkgver" ]; then
-            echo "No update needed. Local and AUR versions match latest."
+          # Download .deb for checksum and Electron detection
+          curl -sf "https://downloads.cursor.com/production/${new_commit}/linux/x64/deb/amd64/deb/cursor_${new_pkgver}_amd64.deb" -o /tmp/cursor.deb
+          new_sha=$(sha512sum /tmp/cursor.deb | cut -d ' ' -f 1)
+          _electron=$(detect_electron_from_deb /tmp/cursor.deb)
+          echo "Detected Electron dependency: ${_electron}"
+
+          if [ "$current_pkgver" != "$new_pkgver" ] || [ "$current_commit" != "$new_commit" ]; then
+            new_pkgrel=1
+          elif [ "$current_electron" != "$_electron" ]; then
+            new_pkgrel=$((current_pkgrel + 1))
+          else
+            new_pkgrel=$current_pkgrel
+          fi
+
+          local_needs_update=false
+          [ "$current_pkgver" != "$new_pkgver" ] && local_needs_update=true
+          [ "$current_commit" != "$new_commit" ] && local_needs_update=true
+          [ "$current_electron" != "$_electron" ] && local_needs_update=true
+          [ "$current_pkgrel" != "$new_pkgrel" ] && local_needs_update=true
+          [ "$current_sha" != "$new_sha" ] && local_needs_update=true
+
+          aur_needs_update=false
+          [ "${aur_pkgver:-}" != "$new_pkgver" ] && aur_needs_update=true
+          [ "${aur_pkgrel:-}" != "$new_pkgrel" ] && aur_needs_update=true
+          [ "${aur_electron:-}" != "$_electron" ] && aur_needs_update=true
+
+          if [ "$local_needs_update" = false ] && [ "$aur_needs_update" = false ]; then
+            echo "No update needed. Local and AUR match latest upstream."
             echo "update_needed=false" >> $GITHUB_OUTPUT
             exit 0
           fi
 
-          echo "Update needed!"
+          if [ "$local_needs_update" = true ] && [ "$aur_needs_update" = false ]; then
+            echo "Update needed: local PKGBUILD out of date."
+          elif [ "$local_needs_update" = false ] && [ "$aur_needs_update" = true ]; then
+            echo "Update needed: AUR package out of sync."
+          else
+            echo "Update needed!"
+          fi
+          if [ "$current_electron" != "$_electron" ]; then
+            echo "Electron dependency fix: ${current_electron:-none} -> ${_electron} (pkgrel ${new_pkgrel})"
+          fi
+
+          electron_fix=false
+          if [ "$current_electron" != "$_electron" ] && [ "$current_pkgver" = "$new_pkgver" ] && [ "$current_commit" = "$new_commit" ]; then
+            electron_fix=true
+          fi
+
+          if [ "$electron_fix" = true ]; then
+            aur_commit_msg="Bump pkgrel to ${new_pkgrel}: fix electron dependency (${_electron})"
+          else
+            aur_commit_msg="Update to version ${new_pkgver} (commit ${new_commit})"
+          fi
+
           echo "update_needed=true" >> $GITHUB_OUTPUT
           echo "new_version=${new_pkgver}" >> $GITHUB_OUTPUT
           echo "new_commit=${new_commit}" >> $GITHUB_OUTPUT
+          echo "new_pkgrel=${new_pkgrel}" >> $GITHUB_OUTPUT
+          echo "new_electron=${_electron}" >> $GITHUB_OUTPUT
+          echo "electron_fix=${electron_fix}" >> $GITHUB_OUTPUT
+          echo "aur_commit_msg=${aur_commit_msg}" >> $GITHUB_OUTPUT
           echo "::endgroup::"
 
           echo "::group::Generating PKGBUILD"
-          # Download .deb file
-          curl -s "https://downloads.cursor.com/production/${new_commit}/linux/x64/deb/amd64/deb/cursor_${new_pkgver}_amd64.deb" -o /tmp/cursor.deb
-
-          # Calculate SHA512
-          new_sha=$(sha512sum /tmp/cursor.deb | cut -d ' ' -f 1)
-
-          # no need to extract VSCode version from product.json as upstream has newer Electron...
-          # code_version=$(bsdtar xOf /tmp/cursor.deb data.tar.xz | bsdtar xOf - ./usr/share/cursor/resources/app/product.json 2>/dev/null | jq -r .vscodeVersion)
-
-          # Get Electron version from VSCode's package-lock.json
-          # By unknown reason, cursor bumps Electron newer than VSCode and mask it from package.json
-          # We could extract from electron --version using Electron's default app, but we don't
-          _electron=electron #$(curl -sL "https://github.com/microsoft/vscode/raw/refs/tags/${code_version}/package-lock.json" | jq -r '.packages."".devDependencies.electron |split(".")|.[0]')
-
-          # echo "VSCode version: ${code_version}"
-          echo "Electron: ${_electron}"
-
-          # Generate PKGBUILD from template
-          # Use awk for sha512sum replacement as sed has issues with brackets
           awk -v pkgver="${new_pkgver}" \
+              -v pkgrel="${new_pkgrel}" \
               -v commit="${new_commit}" \
               -v sha="${new_sha}" \
               -v electron="${_electron}" \
               'BEGIN {OFS=""} 
                /^pkgver=/ {print "pkgver=" pkgver; next}
+               /^pkgrel=/ {print "pkgrel=" pkgrel; next}
                /^_commit=/ {print "_commit=" commit; next}
                /^sha512sums\[0\]=/ {print "sha512sums[0]=" sha; next}
                /^_electron=/ {print "_electron=" electron; next}
                {print}' PKGBUILD.sed > PKGBUILD
 
-          # Basic validation
           if ! grep -q "^pkgver=${new_pkgver}$" PKGBUILD; then
             echo "ERROR: pkgver not set correctly"
+            exit 1
+          fi
+          if ! grep -q "^pkgrel=${new_pkgrel}$" PKGBUILD; then
+            echo "ERROR: pkgrel not set correctly"
             exit 1
           fi
           if ! grep -q "^_commit=${new_commit}" PKGBUILD; then
@@ -121,16 +181,20 @@ jobs:
       - name: Commit changes
         if: steps.check.outputs.update_needed == 'true'
         run: |
-          # Clean up untracked files
           git clean -fd
 
           git config --local user.email "github-actions[bot]@users.noreply.github.com"
           git config --local user.name "github-actions[bot]"
-          # Add PKGBUILD
-          git add PKGBUILD
-          git commit -m "Update PKGBUILD to version ${{ steps.check.outputs.new_version }} (commit ${{ steps.check.outputs.new_commit }})" || echo "No changes to commit"
 
-          # Push changes to repository
+          if [ "${{ steps.check.outputs.electron_fix }}" = "true" ]; then
+            commit_msg="Bump pkgrel to ${{ steps.check.outputs.new_pkgrel }}: fix electron dependency (${{ steps.check.outputs.new_electron }})"
+          else
+            commit_msg="Update PKGBUILD to version ${{ steps.check.outputs.new_version }} (commit ${{ steps.check.outputs.new_commit }})"
+          fi
+
+          git add PKGBUILD
+          git commit -m "$commit_msg" || echo "No changes to commit"
+
           echo "Pushing changes to remote repository..."
           git push "https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}.git" HEAD:${{ github.ref }}
         env:
@@ -163,7 +227,7 @@ jobs:
           commit_username: ${{ secrets.AUR_USERNAME }}
           commit_email: ${{ secrets.AUR_EMAIL }}
           ssh_private_key: ${{ secrets.AUR_SSH_PRIVATE_KEY }}
-          commit_message: "Update to version ${{ steps.check.outputs.new_version }} (commit ${{ steps.check.outputs.new_commit }})"
+          commit_message: ${{ steps.check.outputs.aur_commit_msg }}
           allow_empty_commits: false
           ssh_keyscan_types: rsa,ecdsa,ed25519
           assets: rg.sh
@@ -174,6 +238,8 @@ jobs:
           echo "Update needed: ${{ steps.check.outputs.update_needed }}"
           echo "New version: ${{ steps.check.outputs.new_version }}"
           echo "New commit: ${{ steps.check.outputs.new_commit }}"
+          echo "New pkgrel: ${{ steps.check.outputs.new_pkgrel }}"
+          echo "Electron: ${{ steps.check.outputs.new_electron }}"
           if [ "${{ steps.check.outputs.update_needed }}" = "true" ]; then
             echo "PKGBUILD updated and published to AUR"
           else

--- a/.github/workflows/update-aur.yml
+++ b/.github/workflows/update-aur.yml
@@ -17,6 +17,10 @@ jobs:
         run: |
           echo "::group::Checking for updates"
 
+          electron_is_specified() {
+            [ -n "$1" ] && echo "$1" | grep -qE '^electron[0-9]+$'
+          }
+
           detect_electron_from_deb() {
             local deb=$1 tmpdir major
             tmpdir=$(mktemp -d)
@@ -72,11 +76,24 @@ jobs:
 
           echo "Latest: $new_pkgver (commit: ${new_commit:0:8})"
 
-          # Download .deb for checksum and Electron detection
-          curl -sf "https://downloads.cursor.com/production/${new_commit}/linux/x64/deb/amd64/deb/cursor_${new_pkgver}_amd64.deb" -o /tmp/cursor.deb
-          new_sha=$(sha512sum /tmp/cursor.deb | cut -d ' ' -f 1)
-          _electron=$(detect_electron_from_deb /tmp/cursor.deb)
-          echo "Detected Electron dependency: ${_electron}"
+          needs_deb=false
+          if [ "$current_pkgver" != "$new_pkgver" ] || [ "$current_commit" != "$new_commit" ]; then
+            needs_deb=true
+          elif ! electron_is_specified "$current_electron"; then
+            needs_deb=true
+            echo "Electron dependency not specified in PKGBUILD; will download .deb to detect"
+          fi
+
+          if [ "$needs_deb" = true ]; then
+            curl -sf "https://downloads.cursor.com/production/${new_commit}/linux/x64/deb/amd64/deb/cursor_${new_pkgver}_amd64.deb" -o /tmp/cursor.deb
+            new_sha=$(sha512sum /tmp/cursor.deb | cut -d ' ' -f 1)
+            _electron=$(detect_electron_from_deb /tmp/cursor.deb)
+            echo "Detected Electron dependency: ${_electron}"
+          else
+            echo "Skipping .deb download (version unchanged, electron already specified: ${current_electron})"
+            _electron=$current_electron
+            new_sha=$current_sha
+          fi
 
           if [ "$current_pkgver" != "$new_pkgver" ] || [ "$current_commit" != "$new_commit" ]; then
             new_pkgrel=1

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -32,7 +32,8 @@ package() {
   ln -sf /usr/bin/node ${_app}/resources/helpers/node
   install -Dm755 "${srcdir}/rg.sh" ${_app}/node_modules/@vscode/ripgrep/bin/rg
   ln -sf /usr/bin/xdg-open ${_app}/node_modules/open/xdg-open
-  sed -e "s|code-oss|cursor|g" -e "s|code.mjs|cursor.mjs|g" \
+  sed -e "1s|.*|#!/usr/lib/${_electron}/electron|" \
+      -e "s|code-oss|cursor|g" -e "s|code.mjs|cursor.mjs|g" \
     "${srcdir}"/code.mjs | install -Dm644 /dev/stdin "${pkgdir}/${_app}/cursor.mjs"
   sed -e "s|code-flags|cursor-flags|" -e "s|/usr/lib/code|/${_app}|" -e "s|/usr/lib/code/code.mjs|/${_app}/cursor.mjs|" \
     -e "s|name=electron|name=${_electron}|" "${srcdir}"/code.sh | install -Dm755 /dev/stdin "${pkgdir}"/usr/share/cursor/cursor

--- a/PKGBUILD.sed
+++ b/PKGBUILD.sed
@@ -32,7 +32,8 @@ package() {
   ln -sf /usr/bin/node ${_app}/resources/helpers/node
   install -Dm755 "${srcdir}/rg.sh" ${_app}/node_modules/@vscode/ripgrep/bin/rg
   ln -sf /usr/bin/xdg-open ${_app}/node_modules/open/xdg-open
-  sed -e "s|code-oss|cursor|g" -e "s|code.mjs|cursor.mjs|g" \
+  sed -e "1s|.*|#!/usr/lib/${_electron}/electron|" \
+      -e "s|code-oss|cursor|g" -e "s|code.mjs|cursor.mjs|g" \
     "${srcdir}"/code.mjs | install -Dm644 /dev/stdin "${pkgdir}/${_app}/cursor.mjs"
   sed -e "s|code-flags|cursor-flags|" -e "s|/usr/lib/code|/${_app}|" -e "s|/usr/lib/code/code.mjs|/${_app}/cursor.mjs|" \
     -e "s|name=electron|name=${_electron}|" "${srcdir}"/code.sh | install -Dm755 /dev/stdin "${pkgdir}"/usr/share/cursor/cursor

--- a/README.md
+++ b/README.md
@@ -1,190 +1,122 @@
 # AUR Cursor Binary Package Updater
 
-Automated maintenance system for the [cursor-bin](https://aur.archlinux.org/packages/cursor-bin) AUR package. This repository automatically monitors Cursor IDE releases and maintains the PKGBUILD for Arch Linux users.
+Automated maintenance for the [cursor-bin](https://aur.archlinux.org/packages/cursor-bin) AUR package. This repository monitors Cursor releases and keeps the PKGBUILD in sync for Arch Linux users.
 
-## 🎯 What This Repository Does
+## What This Repository Does
 
-This is **not** a manual installation guide for Cursor IDE. Instead, it's an automated system that:
+This is **not** an installation guide for Cursor. It is the automation that:
 
-- 🔍 **Monitors** Cursor IDE releases automatically via GitHub Actions
-- 📦 **Generates** proper PKGBUILDs with correct versions, checksums, and dependencies  
-- 🚀 **Publishes** updates to the AUR automatically
-- ✅ **Validates** all changes with comprehensive testing (25+ checks)
-- 🔧 **Maintains** the package using modern .deb format (not AppImage)
+- Monitors Cursor releases via GitHub Actions (hourly, plus manual trigger)
+- Generates PKGBUILDs with correct version, commit, checksum, and Electron dependency
+- Publishes updates to the AUR automatically from `main`
 
-## 📥 Installing Cursor IDE (End Users)
+The package itself repackages Cursor's official `.deb` and follows the same system-Electron approach as Arch's [`extra/code`](https://gitlab.archlinux.org/archlinux/packaging/packages/code) package.
 
-If you just want to **install** Cursor IDE on Arch Linux, use your AUR helper:
+## Installing Cursor (End Users)
+
+Use your AUR helper:
 
 ```bash
-# Using yay
 yay -S cursor-bin
-
-# Using paru  
+# or
 paru -S cursor-bin
-
-# Using makepkg (manual)
-git clone https://aur.archlinux.org/cursor-bin.git
-cd cursor-bin
-makepkg -si
 ```
 
-## 🛠️ Development & Maintenance
-
-### Architecture Overview
-
-```
-┌─────────────────┐    ┌──────────────────┐    ┌─────────────────┐
-│   Cursor.com    │───▶│  GitHub Actions  │───▶│  AUR Package    │
-│   (releases)    │    │  (this repo)     │    │  (cursor-bin)   │
-└─────────────────┘    └──────────────────┘    └─────────────────┘
-                              │
-                              ▼
-                       ┌──────────────────┐
-                       │   Validation     │
-                       │   (25+ checks)   │
-                       └──────────────────┘
-```
-
-### Key Components
+## Repository Layout
 
 | File | Purpose |
 |------|---------|
-| `.github/workflows/update-aur.yml` | Automated GitHub Actions workflow |
-| `PKGBUILD` | The actual package build script |
+| `.github/workflows/update-aur.yml` | CI workflow: check, generate, commit, publish |
+| `PKGBUILD.sed` | Template used to generate `PKGBUILD` |
+| `PKGBUILD` | Current package definition (updated by CI) |
+| `rg.sh` | Ripgrep wrapper shipped with the AUR package |
+| `test_bash_workflow.sh` | Local test script mirroring the CI workflow |
+| `TESTING.md` | Safe testing guide before merging to `main` |
 
-### Automated Workflow
+## Automated Workflow
 
-1. **🕐 Scheduled Check**: GitHub Actions runs daily (and on manual trigger)
-2. **🔍 Version Detection**: `check.py` compares latest Cursor version with AUR
-3. **📦 PKGBUILD Update**: `update_pkgbuild.py` generates new PKGBUILD with:
-   - Correct version and commit hash
-   - Updated download URLs  
-   - Recalculated SHA512 checksums
-   - Dynamic Electron version detection
-4. **✅ Validation**: 25+ comprehensive checks ensure quality *(development branch only)*
-5. **🚀 AUR Publish**: Automatic commit and push to AUR *(main branch only)*
+1. Query Cursor's stable update API and the AUR RPC for the current package state
+2. Download the upstream `.deb`
+3. Detect the required `electronXX` dependency from the bundled Cursor binary
+4. Decide whether an update is needed (see below)
+5. Generate `PKGBUILD` from `PKGBUILD.sed`
+6. Commit to this repo and publish to AUR (`main` only)
 
-**Branch Behavior**:
-- **Development**: Runs steps 1-4, skips AUR publish for safe testing
-- **Main**: Runs steps 1-3 + 5, skips validation for faster production updates
+### When an Update Triggers
 
-### Local Development
+An update runs if **any** of these are out of sync with upstream:
 
-#### Prerequisites
+- Local `pkgver`, `_commit`, `_electron`, `pkgrel`, or checksum
+- AUR version, pkgrel, or Electron dependency
 
-```bash
+Even when Cursor's version hasn't changed, a wrong Electron dependency (for example `electron` instead of `electron39`) will trigger a rebuild and **pkgrel bump**.
 
-# For local testing (optional)
-yay -S act-bin  # GitHub Actions local runner
-```
-
-#### Manual Update Process
-
-```bash
-# 1. Check for updates
-python check.py
-
-# 2. Apply updates (if needed)
-python update_pkgbuild.py check_output.json
-
-# 3. Validate the result
-python validate_pkgbuild.py
-
-# 4. Test locally
-makepkg -s
-```
-
-#### Full Workflow Testing
-
-```bash
-# Test the complete GitHub Actions workflow locally
-python test_workflow.py --run
-```
-
-This simulates the entire automated process including:
-- Version downgrade simulation
-- Complete workflow execution in Docker
-- Comprehensive validation
-- Result reporting
-
-### Branch Strategy
-
-- **`main`**: Production branch - triggers actual AUR updates (no validation step)
-- **`development`**: Testing branch - runs comprehensive validation + DEBUG mode (no AUR push)
-
-**Important**: The 25+ validation checks only run automatically on the `development` branch. This ensures thorough testing before changes reach production.
-
-### Validation System
-
-The system performs 25+ comprehensive checks:
-
-| Category | Checks |
-|----------|--------|
-| **Format** | Version format, pkgrel validation, commit hash format |
-| **Content** | SHA512 checksums, electron version, source URLs |
-| **Functionality** | Tool availability, URL accessibility, command syntax |
-| **Integration** | Native titlebar fix, cursor.sh transformation |
-| **Advanced** | Dynamic electron detection, actual file verification |
-
-## 🔧 Advanced Features
+On a new upstream release, `pkgrel` resets to `1`.
 
 ### Electron Version Detection
 
-The system automatically detects the correct Electron version by:
-1. Extracting VSCode version from Cursor's `product.json`
-2. Downloading VSCode source tarball
-3. Parsing `package-lock.json` for Electron dependencies
-4. Updating PKGBUILD with correct `electronXX` package
-
-### Debug Mode
-
-Enable verbose logging for troubleshooting:
+Cursor ships a newer Electron than its embedded VSCode version reports, so the workflow reads the bundled binary inside the `.deb`:
 
 ```bash
-DEBUG=true python check.py
-DEBUG=true python update_pkgbuild.py check_output.json
+ar x cursor.deb data.tar.xz
+tar xJf data.tar.xz -O ./usr/share/cursor/cursor | strings | grep -oE 'Electron/[0-9]+'
 ```
 
-## 🤝 Contributing
+The major version becomes the `_electron=electronXX` dependency and launcher path.
 
-### Reporting Issues
+### Branch Behavior
 
-- **Package Issues**: Report to [AUR cursor-bin page](https://aur.archlinux.org/packages/cursor-bin)
-- **Automation Issues**: Create issues in this repository
+| Branch | Commits to repo | Publishes to AUR |
+|--------|-----------------|------------------|
+| `main` | Yes | Yes |
+| `development` | Yes | No (stops before SSH/AUR deploy) |
 
-### Development
+Use `development` to verify generated PKGBUILDs before they reach the AUR. See [TESTING.md](TESTING.md) for details.
 
-1. Fork this repository
-2. Create feature branch from `development`
-3. Test changes with `python test_workflow.py --run`
-4. Submit PR against `development` branch
+## Local Development
 
-### Adding New Checks
+### Test the workflow logic
 
-To add validation checks, modify `validate_pkgbuild.py`:
-
-```python
-# Add new check in validate_pkgbuild() function
-results["checks"].append({
-    "check": "your_check_name",
-    "status": "pass" or "fail", 
-    "message": "Description of what was checked"
-})
+```bash
+./test_bash_workflow.sh
 ```
 
-## 📊 Monitoring
+This mirrors the CI steps without committing or touching the AUR. Output is written to `PKGBUILD.test`.
 
-- **GitHub Actions**: Check workflow runs for automation status
-- **AUR Package**: Monitor [cursor-bin](https://aur.archlinux.org/packages/cursor-bin) for updates
-- **Issues**: Watch this repository for automation problems
+Dependencies: `curl`, `jq`, `ar`, `tar`, `sha512sum`, `awk`, `grep`, `strings` (all standard on Arch).
 
-## 🔗 Related Links
+### Test a build
 
-- [Cursor IDE Official Site](https://www.cursor.com)
-- [AUR cursor-bin Package](https://aur.archlinux.org/packages/cursor-bin)
-- [Arch Linux AUR Guidelines](https://wiki.archlinux.org/title/AUR_submission_guidelines)
+```bash
+./test_bash_workflow.sh
+mv PKGBUILD.test PKGBUILD
+makepkg -si
+```
 
----
+### Run GitHub Actions locally (optional)
 
-**Note**: This repository maintains the AUR package automatically. End users should install `cursor-bin` directly from the AUR, not from this repository.
+```bash
+yay -S act-bin
+act workflow_dispatch
+```
+
+## Contributing
+
+- **Package/runtime issues**: [AUR cursor-bin](https://aur.archlinux.org/packages/cursor-bin)
+- **Automation issues**: issues/PRs in this repository
+
+1. Branch from `development`
+2. Test with `./test_bash_workflow.sh`
+3. Optionally push to `development` and verify the GitHub Actions run
+4. Open a PR against `development`, then merge to `main` when ready
+
+## Monitoring
+
+- [GitHub Actions](../../actions) — workflow runs
+- [AUR cursor-bin](https://aur.archlinux.org/packages/cursor-bin) — published package
+
+## Related Links
+
+- [Cursor](https://www.cursor.com)
+- [Arch `code` PKGBUILD](https://gitlab.archlinux.org/archlinux/packaging/packages/code) — upstream packaging this derives from
+- [AUR submission guidelines](https://wiki.archlinux.org/title/AUR_submission_guidelines)

--- a/TESTING.md
+++ b/TESTING.md
@@ -116,7 +116,8 @@ git checkout PKGBUILD
 ### 2. PKGBUILD Generation
 - ✅ `pkgver` is set correctly
 - ✅ `_commit` is set correctly
-- ✅ `_electron` is determined correctly
+- ✅ `pkgrel` is set correctly (reset on version bump, incremented on electron-only fix)
+- ✅ `_electron` is detected from the bundled Cursor binary
 - ✅ `sha512sum[0]` is calculated correctly
 - ✅ `ripgrep` dependency is present
 - ✅ All other dependencies are preserved
@@ -169,12 +170,12 @@ Before merging to `main`:
 - Check for special characters in values
 
 ### Electron version detection fails
-- Check VSCode version extraction
-- Verify GitHub API access
-- Check jq parsing of package-lock.json
+- Check that `ar` and `tar` can extract `./usr/share/cursor/cursor` from the downloaded `.deb`
+- Verify `strings` finds `Electron/NN` in the bundled binary
+- Confirm the detected major version matches an `electronNN` package in Arch repos
 
 ### Local test script fails
-- Install missing dependencies: `sudo pacman -S libarchive jq curl`
+- Install missing dependencies: `sudo pacman -S binutils jq curl`
 - Check network connectivity
 - Verify Cursor API is accessible
 

--- a/test_bash_workflow.sh
+++ b/test_bash_workflow.sh
@@ -8,6 +8,10 @@ echo "🧪 Testing bash-based PKGBUILD generation workflow"
 echo "=================================================="
 echo ""
 
+electron_is_specified() {
+  [ -n "$1" ] && echo "$1" | grep -qE '^electron[0-9]+$'
+}
+
 detect_electron_from_deb() {
   local deb=$1 tmpdir major
   tmpdir=$(mktemp -d)
@@ -86,16 +90,30 @@ fi
 echo "Latest: $NEW_PKGVER (commit: ${NEW_COMMIT:0:8})"
 echo ""
 
-echo "⬇️  Downloading .deb file..."
-curl -sf "https://downloads.cursor.com/production/${NEW_COMMIT}/linux/x64/deb/amd64/deb/cursor_${NEW_PKGVER}_amd64.deb" -o /tmp/cursor_test.deb
+NEEDS_DEB=false
+if [ "$CURRENT_PKGVER" != "$NEW_PKGVER" ] || [ "$CURRENT_COMMIT" != "$NEW_COMMIT" ]; then
+  NEEDS_DEB=true
+elif ! electron_is_specified "$CURRENT_ELECTRON"; then
+  NEEDS_DEB=true
+  echo "Electron dependency not specified in PKGBUILD; will download .deb to detect"
+fi
 
-echo "🔐 Calculating SHA512 checksum..."
-NEW_SHA=$(sha512sum /tmp/cursor_test.deb | cut -d ' ' -f 1)
-echo "SHA512: ${NEW_SHA:0:20}..."
+if [ "$NEEDS_DEB" = true ]; then
+  echo "⬇️  Downloading .deb file..."
+  curl -sf "https://downloads.cursor.com/production/${NEW_COMMIT}/linux/x64/deb/amd64/deb/cursor_${NEW_PKGVER}_amd64.deb" -o /tmp/cursor_test.deb
 
-echo "⚡ Detecting Electron version from bundled binary..."
-_ELECTRON=$(detect_electron_from_deb /tmp/cursor_test.deb)
-echo "Detected Electron dependency: ${_ELECTRON}"
+  echo "🔐 Calculating SHA512 checksum..."
+  NEW_SHA=$(sha512sum /tmp/cursor_test.deb | cut -d ' ' -f 1)
+  echo "SHA512: ${NEW_SHA:0:20}..."
+
+  echo "⚡ Detecting Electron version from bundled binary..."
+  _ELECTRON=$(detect_electron_from_deb /tmp/cursor_test.deb)
+  echo "Detected Electron dependency: ${_ELECTRON}"
+else
+  echo "⏭️  Skipping .deb download (version unchanged, electron already specified: ${CURRENT_ELECTRON})"
+  _ELECTRON=$CURRENT_ELECTRON
+  NEW_SHA=$CURRENT_SHA
+fi
 echo ""
 
 if [ "$CURRENT_PKGVER" != "$NEW_PKGVER" ] || [ "$CURRENT_COMMIT" != "$NEW_COMMIT" ]; then

--- a/test_bash_workflow.sh
+++ b/test_bash_workflow.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # Local test script for the bash-based PKGBUILD generation workflow
-# This simulates what the GitHub Actions workflow does without committing anything
+# Mirrors .github/workflows/update-aur.yml without committing anything
 
 set -e
 
@@ -8,204 +8,204 @@ echo "🧪 Testing bash-based PKGBUILD generation workflow"
 echo "=================================================="
 echo ""
 
-# Check dependencies
+detect_electron_from_deb() {
+  local deb=$1 tmpdir major
+  tmpdir=$(mktemp -d)
+  cp "$deb" "$tmpdir/pkg.deb"
+  (cd "$tmpdir" && ar x pkg.deb data.tar.xz)
+  major=$(tar xJf "$tmpdir/data.tar.xz" -O ./usr/share/cursor/cursor \
+    | strings | grep -oE 'Electron/[0-9]+' | head -1 | cut -d/ -f2)
+  rm -rf "$tmpdir"
+  if [ -z "$major" ]; then
+    echo "ERROR: Failed to detect Electron version from .deb" >&2
+    exit 1
+  fi
+  echo "electron${major}"
+}
+
 echo "📦 Checking dependencies..."
-for cmd in curl jq bsdtar sha512sum sed grep; do
-    if ! command -v $cmd &> /dev/null; then
-        echo "❌ Missing: $cmd"
-        exit 1
-    fi
+for cmd in curl jq ar tar sha512sum awk grep strings; do
+  if ! command -v $cmd &> /dev/null; then
+    echo "❌ Missing: $cmd"
+    exit 1
+  fi
 done
 echo "✓ All dependencies available"
 echo ""
 
-# Check if PKGBUILD.sed exists
 if [ ! -f PKGBUILD.sed ]; then
-    echo "❌ PKGBUILD.sed not found!"
-    exit 1
+  echo "❌ PKGBUILD.sed not found!"
+  exit 1
 fi
 
-# Get current version from PKGBUILD if it exists
 if [ -f PKGBUILD ]; then
-    CURRENT_PKGVER=$(grep -E '^pkgver=' PKGBUILD | cut -d'=' -f2)
-    CURRENT_COMMIT=$(grep -E '^_commit=' PKGBUILD | cut -d'=' -f2 | sed 's/ #.*//')
+  CURRENT_PKGVER=$(grep -E '^pkgver=' PKGBUILD | cut -d'=' -f2)
+  CURRENT_PKGREL=$(grep -E '^pkgrel=' PKGBUILD | cut -d'=' -f2)
+  CURRENT_PKGREL=${CURRENT_PKGREL:-1}
+  CURRENT_COMMIT=$(grep -E '^_commit=' PKGBUILD | cut -d'=' -f2 | sed 's/ #.*//')
+  CURRENT_ELECTRON=$(grep -E '^_electron=' PKGBUILD | cut -d'=' -f2)
+  CURRENT_SHA=$(grep -E '^sha512sums\[0\]=' PKGBUILD | cut -d'=' -f2)
 else
-    CURRENT_PKGVER=""
-    CURRENT_COMMIT=""
+  CURRENT_PKGVER=""
+  CURRENT_PKGREL=1
+  CURRENT_COMMIT=""
+  CURRENT_ELECTRON=""
+  CURRENT_SHA=""
 fi
 
-echo ""
 echo "🔍 Checking for updates..."
+echo "Local version: ${CURRENT_PKGVER:-none}-${CURRENT_PKGREL:-?} (commit: ${CURRENT_COMMIT:0:8}, ${CURRENT_ELECTRON:-unknown})"
 
-MAJOR=$(echo "$CURRENT_PKGVER" | cut -d'.' -f1)
-MINOR=$(echo "$CURRENT_PKGVER" | cut -d'.' -f2)
-echo "Current version: ${CURRENT_PKGVER} (major: $MAJOR, minor: $MINOR)"
+AUR_PKGVER=""
+AUR_PKGREL=""
+AUR_ELECTRON=""
+aur_response=$(curl -sf "https://aur.archlinux.org/rpc/?v=5&type=info&arg[]=cursor-bin" || true)
+if [ -n "$aur_response" ]; then
+  aur_version=$(echo "$aur_response" | jq -r '.results[0].Version // empty')
+  AUR_PKGVER=$(echo "$aur_version" | cut -d'-' -f1)
+  AUR_PKGREL=$(echo "$aur_version" | cut -d'-' -f2)
+  AUR_ELECTRON=$(echo "$aur_response" | jq -r '.results[0].Depends[]? | select(test("^electron"))' | head -1)
+fi
+echo "AUR version: ${AUR_PKGVER:-unknown}-${AUR_PKGREL:-?} (${AUR_ELECTRON:-unknown electron dep})"
 
-# Helper functions
-get_redirect() {
-    curl -sI "https://api2.cursor.sh/updates/download/golden/linux-x64-deb/cursor/$1" | grep -i '^location:' | cut -d' ' -f2 | tr -d '\r\n'
-}
-
-extract_version() { echo "$1" | sed -n 's|.*cursor_\([0-9.]*\)_amd64.*|\1|p'; }
-extract_commit() { echo "$1" | sed -n 's|.*/production/\([^/]*\).*|\1|p'; }
-version_to_number() { echo "$1" | awk -F. '{printf "%d%03d%03d", $1, $2, $3}'; }
-
-# Check a major version series, stores best redirect in BEST_REDIRECT if higher
-check_major_series() {
-    local major=$1 start_minor=$2 minor=$start_minor max_checks=20
-    echo "Checking major version $major..."
-    while [ $((minor - start_minor)) -lt $max_checks ]; do
-        local redirect=$(get_redirect "$major.$minor")
-        [ -z "$redirect" ] && { echo "  $major.$minor -> (no response)"; break; }
-        
-        local ver=$(extract_version "$redirect")
-        echo "  $major.$minor -> $ver"
-        
-        local ver_num=$(version_to_number "$ver")
-        [ "$ver_num" -gt "$BEST_NUM" ] && { BEST_NUM=$ver_num; BEST_REDIRECT=$redirect; }
-        
-        # Fallback detection: returned major.minor < checked major.minor means stop
-        local ret_mm=$(echo "$ver" | cut -d'.' -f1-2)
-        [ "$(version_to_number "$ret_mm.0")" -lt "$(version_to_number "$major.$minor.0")" ] && { echo "  (fallback detected, stopping)"; break; }
-        
-        minor=$((minor + 1))
-    done
-}
-
-# Find the latest version by checking current and next major
-BEST_REDIRECT=""
-BEST_NUM=0
-check_major_series "$MAJOR" "$MINOR"
-check_major_series "$((MAJOR + 1))" 0
-
-if [ -z "$BEST_REDIRECT" ]; then
-    echo "❌ ERROR: Failed to get version from any endpoint"
-    exit 1
+api_response=$(curl -sf "https://api2.cursor.sh/updates/api/update/linux-x64/cursor/0.0.0/deadbeef/stable")
+if [ -z "$api_response" ]; then
+  echo "❌ ERROR: Failed to get response from update API"
+  exit 1
 fi
 
-# Extract version and commit from the best redirect (no re-check needed)
-NEW_PKGVER=$(extract_version "$BEST_REDIRECT")
-NEW_COMMIT=$(extract_commit "$BEST_REDIRECT")
-echo "Latest version found: $NEW_PKGVER"
+NEW_PKGVER=$(echo "$api_response" | jq -r '.version')
+api_url=$(echo "$api_response" | jq -r '.url')
+NEW_COMMIT=$(echo "$api_url" | sed -n 's|.*/production/\([^/]*\).*|\1|p')
 
 if [ -z "$NEW_PKGVER" ] || [ -z "$NEW_COMMIT" ]; then
-    echo "❌ ERROR: Failed to extract version or commit from redirect URL"
-    exit 1
+  echo "❌ ERROR: Failed to extract version or commit from API response"
+  exit 1
 fi
 
-echo "Current version: ${CURRENT_PKGVER:-none}"
-echo "Current commit: ${CURRENT_COMMIT:-none}"
-echo "New version: ${NEW_PKGVER}"
-echo "New commit: ${NEW_COMMIT}"
+echo "Latest: $NEW_PKGVER (commit: ${NEW_COMMIT:0:8})"
 echo ""
 
-# Check if update is needed
-if [ "$CURRENT_PKGVER" = "$NEW_PKGVER" ] && [ "$CURRENT_COMMIT" = "$NEW_COMMIT" ]; then
-    echo "ℹ️  No update needed. Current version matches latest."
-    echo ""
-    echo "💡 To force a test, you can temporarily modify PKGBUILD version"
-    exit 0
-fi
-
-echo "📥 Update needed! Generating PKGBUILD..."
-echo ""
-
-# Download .deb file
 echo "⬇️  Downloading .deb file..."
-curl -s "https://downloads.cursor.com/production/${NEW_COMMIT}/linux/x64/deb/amd64/deb/cursor_${NEW_PKGVER}_amd64.deb" -o /tmp/cursor_test.deb
+curl -sf "https://downloads.cursor.com/production/${NEW_COMMIT}/linux/x64/deb/amd64/deb/cursor_${NEW_PKGVER}_amd64.deb" -o /tmp/cursor_test.deb
 
-# Calculate SHA512
 echo "🔐 Calculating SHA512 checksum..."
 NEW_SHA=$(sha512sum /tmp/cursor_test.deb | cut -d ' ' -f 1)
 echo "SHA512: ${NEW_SHA:0:20}..."
 
-# Extract VSCode version from product.json
-echo "📦 Extracting VSCode version..."
-CODE_VERSION=$(bsdtar xOf /tmp/cursor_test.deb data.tar.xz 2>/dev/null | bsdtar xOf - ./usr/share/cursor/resources/app/product.json 2>/dev/null | jq -r .vscodeVersion)
-echo "VSCode version: ${CODE_VERSION}"
-
-# Get Electron version from VSCode's package-lock.json
-echo "⚡ Determining Electron version..."
-_ELECTRON=electron$(curl -sL "https://github.com/microsoft/vscode/raw/refs/tags/${CODE_VERSION}/package-lock.json" | jq -r '.packages."".devDependencies.electron |split(".")|.[0]')
-echo "Electron: ${_ELECTRON}"
+echo "⚡ Detecting Electron version from bundled binary..."
+_ELECTRON=$(detect_electron_from_deb /tmp/cursor_test.deb)
+echo "Detected Electron dependency: ${_ELECTRON}"
 echo ""
 
-# Generate PKGBUILD from template
+if [ "$CURRENT_PKGVER" != "$NEW_PKGVER" ] || [ "$CURRENT_COMMIT" != "$NEW_COMMIT" ]; then
+  NEW_PKGREL=1
+elif [ "$CURRENT_ELECTRON" != "$_ELECTRON" ]; then
+  NEW_PKGREL=$((CURRENT_PKGREL + 1))
+else
+  NEW_PKGREL=$CURRENT_PKGREL
+fi
+
+LOCAL_NEEDS_UPDATE=false
+[ "$CURRENT_PKGVER" != "$NEW_PKGVER" ] && LOCAL_NEEDS_UPDATE=true
+[ "$CURRENT_COMMIT" != "$NEW_COMMIT" ] && LOCAL_NEEDS_UPDATE=true
+[ "$CURRENT_ELECTRON" != "$_ELECTRON" ] && LOCAL_NEEDS_UPDATE=true
+[ "$CURRENT_PKGREL" != "$NEW_PKGREL" ] && LOCAL_NEEDS_UPDATE=true
+[ "$CURRENT_SHA" != "$NEW_SHA" ] && LOCAL_NEEDS_UPDATE=true
+
+AUR_NEEDS_UPDATE=false
+[ "${AUR_PKGVER:-}" != "$NEW_PKGVER" ] && AUR_NEEDS_UPDATE=true
+[ "${AUR_PKGREL:-}" != "$NEW_PKGREL" ] && AUR_NEEDS_UPDATE=true
+[ "${AUR_ELECTRON:-}" != "$_ELECTRON" ] && AUR_NEEDS_UPDATE=true
+
+if [ "$LOCAL_NEEDS_UPDATE" = false ] && [ "$AUR_NEEDS_UPDATE" = false ]; then
+  echo "ℹ️  No update needed. Local and AUR match latest upstream."
+  exit 0
+fi
+
+if [ "$CURRENT_ELECTRON" != "$_ELECTRON" ]; then
+  echo "📥 Update needed: electron dependency fix (${CURRENT_ELECTRON:-none} -> ${_ELECTRON}, pkgrel ${NEW_PKGREL})"
+else
+  echo "📥 Update needed!"
+fi
+echo ""
+
 echo "📝 Generating PKGBUILD from template..."
-# Use awk for sha512sum replacement as sed has issues with brackets
 awk -v pkgver="$NEW_PKGVER" \
+    -v pkgrel="$NEW_PKGREL" \
     -v commit="$NEW_COMMIT" \
     -v sha="$NEW_SHA" \
     -v electron="$_ELECTRON" \
     'BEGIN {OFS=""} 
      /^pkgver=/ {print "pkgver=" pkgver; next}
-     /^_commit=/ {print "_commit=" commit " # sed'\''ded at GitHub WF"; next}
+     /^pkgrel=/ {print "pkgrel=" pkgrel; next}
+     /^_commit=/ {print "_commit=" commit; next}
      /^sha512sums\[0\]=/ {print "sha512sums[0]=" sha; next}
      /^_electron=/ {print "_electron=" electron; next}
      {print}' PKGBUILD.sed > PKGBUILD.test || {
-    echo "❌ ERROR: Failed to generate PKGBUILD"
-    exit 1
+  echo "❌ ERROR: Failed to generate PKGBUILD"
+  exit 1
 }
 
 echo ""
 echo "✅ Validation checks..."
-# Temporarily disable exit on error for validation
 set +e
 VALIDATION_FAILED=0
 
-# Basic validation
 if ! grep -q "^pkgver=${NEW_PKGVER}$" PKGBUILD.test; then
-    echo "❌ ERROR: pkgver not set correctly"
-    VALIDATION_FAILED=1
+  echo "❌ ERROR: pkgver not set correctly"
+  VALIDATION_FAILED=1
 else
-    echo "✓ pkgver is correct"
+  echo "✓ pkgver is correct"
+fi
+
+if ! grep -q "^pkgrel=${NEW_PKGREL}$" PKGBUILD.test; then
+  echo "❌ ERROR: pkgrel not set correctly"
+  VALIDATION_FAILED=1
+else
+  echo "✓ pkgrel is correct"
 fi
 
 if ! grep -q "^_commit=${NEW_COMMIT}" PKGBUILD.test; then
-    echo "❌ ERROR: _commit not set correctly"
-    VALIDATION_FAILED=1
+  echo "❌ ERROR: _commit not set correctly"
+  VALIDATION_FAILED=1
 else
-    echo "✓ _commit is correct"
+  echo "✓ _commit is correct"
 fi
 
 if ! grep -q "^_electron=${_ELECTRON}$" PKGBUILD.test; then
-    echo "❌ ERROR: _electron not set correctly"
-    VALIDATION_FAILED=1
+  echo "❌ ERROR: _electron not set correctly"
+  VALIDATION_FAILED=1
 else
-    echo "✓ _electron is correct"
+  echo "✓ _electron is correct"
 fi
 
 if ! grep -q "^sha512sums\[0\]=${NEW_SHA}" PKGBUILD.test; then
-    echo "❌ ERROR: sha512sum not set correctly"
-    echo "   Expected: sha512sum[0]=${NEW_SHA:0:20}..."
-    echo "   Got: $(grep '^sha512sums\[0\]=' PKGBUILD.test || echo 'not found')"
-    VALIDATION_FAILED=1
+  echo "❌ ERROR: sha512sum not set correctly"
+  echo "   Expected: sha512sums[0]=${NEW_SHA:0:20}..."
+  echo "   Got: $(grep '^sha512sums\[0\]=' PKGBUILD.test || echo 'not found')"
+  VALIDATION_FAILED=1
 else
-    echo "✓ sha512sum is correct"
+  echo "✓ sha512sum is correct"
 fi
 
-# Check for ripgrep dependency
 if ! grep -q "ripgrep" PKGBUILD.test; then
-    echo "❌ ERROR: ripgrep dependency missing!"
-    VALIDATION_FAILED=1
+  echo "❌ ERROR: ripgrep dependency missing!"
+  VALIDATION_FAILED=1
 else
-    echo "✓ ripgrep dependency present"
+  echo "✓ ripgrep dependency present"
 fi
 
 echo ""
 
 set -e
 if [ $VALIDATION_FAILED -eq 1 ]; then
-    echo "❌ Validation failed!"
-    echo ""
-    echo "Generated PKGBUILD content (for debugging):"
-    echo "============================================"
-    if [ -f PKGBUILD.test ]; then
-        cat PKGBUILD.test
-    else
-        echo "PKGBUILD.test was not created!"
-    fi
-    exit 1
+  echo "❌ Validation failed!"
+  echo ""
+  echo "Generated PKGBUILD content (for debugging):"
+  echo "============================================"
+  cat PKGBUILD.test
+  exit 1
 fi
 
 echo "✅ All validations passed!"
@@ -215,34 +215,30 @@ echo "========================"
 cat PKGBUILD.test
 echo ""
 
-# Optionally test with makepkg (if on Arch Linux)
 if command -v makepkg &> /dev/null; then
-    read -p "🧪 Test with makepkg? (y/N) " -n 1 -r
-    echo
-    if [[ $REPLY =~ ^[Yy]$ ]]; then
-        echo ""
-        echo "🧪 Testing PKGBUILD with makepkg (dry run)..."
-        # Backup original PKGBUILD only when needed for makepkg test
-        if [ -f PKGBUILD ]; then
-            cp PKGBUILD PKGBUILD.backup
-        fi
-        cp PKGBUILD.test PKGBUILD
-        makepkg --verifysource --noconfirm || echo "⚠️  makepkg test had issues (this is expected if source files aren't available)"
-        # Restore original PKGBUILD
-        if [ -f PKGBUILD.backup ]; then
-            mv PKGBUILD.backup PKGBUILD
-            echo "✓ Restored original PKGBUILD"
-        fi
+  read -p "🧪 Test with makepkg? (y/N) " -n 1 -r
+  echo
+  if [[ $REPLY =~ ^[Yy]$ ]]; then
+    echo ""
+    echo "🧪 Testing PKGBUILD with makepkg (dry run)..."
+    if [ -f PKGBUILD ]; then
+      cp PKGBUILD PKGBUILD.backup
     fi
+    cp PKGBUILD.test PKGBUILD
+    makepkg --verifysource --noconfirm || echo "⚠️  makepkg test had issues (this is expected if source files aren't available)"
+    if [ -f PKGBUILD.backup ]; then
+      mv PKGBUILD.backup PKGBUILD
+      echo "✓ Restored original PKGBUILD"
+    fi
+  fi
 fi
 
 echo ""
 echo "📋 Summary:"
 echo "==========="
 echo "Generated PKGBUILD saved as: PKGBUILD.test"
-if [ -f PKGBUILD.backup ]; then
-    echo "Original PKGBUILD preserved as: PKGBUILD.backup (from makepkg test)"
-fi
+echo "Target version: ${NEW_PKGVER}-${NEW_PKGREL}"
+echo "Electron dependency: ${_ELECTRON}"
 echo ""
 echo "To review the generated PKGBUILD:"
 echo "  cat PKGBUILD.test"
@@ -253,4 +249,3 @@ echo ""
 echo "To use the generated PKGBUILD:"
 echo "  mv PKGBUILD.test PKGBUILD"
 echo ""
-


### PR DESCRIPTION
## Summary
- Autodetect the correct `electronXX` dependency from the bundled Cursor binary instead of pinning the rolling `electron` meta package
- Trigger AUR rebuilds when the electron dependency is wrong, even if the Cursor version is unchanged, and bump `pkgrel` accordingly
- Patch `cursor.mjs` shebang to match Arch's `extra/code` packaging
- Bring `test_bash_workflow.sh`, README, and TESTING docs in line with the workflow

Made with [Cursor](https://cursor.com)